### PR TITLE
Export RewriterFunc adapter type

### DIFF
--- a/example_rewrite_test.go
+++ b/example_rewrite_test.go
@@ -17,11 +17,11 @@ func ExampleRewriter() {
 	clean := textutil.NewTransformer(&cleanSpaces{})
 	fmt.Println(clean.String("  Hello   world! \t Hello   world!   ")) // Hello world! Hello world!
 
-	escape := textutil.NewTransformerFromFunc(escape)
+	escape := textutil.NewTransformer(textutil.RewriterFunc(escape))
 	escaped := escape.String("Héllø wørl∂!") // H\u00E9ll\u00F8 w\u00F8rl\u2202!
 	fmt.Println(escaped)
 
-	unescape := textutil.NewTransformerFromFunc(unescape)
+	unescape := textutil.NewTransformer(textutil.RewriterFunc(unescape))
 	fmt.Println(unescape.String(escaped)) // Héllø wørl∂!
 
 	// As usual, Transformers can be chained together:

--- a/rewrite_test.go
+++ b/rewrite_test.go
@@ -32,8 +32,8 @@ func (rwReplaceAll) Rewrite(s State) {
 	s.WriteRune('a')
 }
 
-func rw(r func(State)) transform.SpanningTransformer {
-	return NewTransformerFromFunc(r)
+func rw(r RewriterFunc) transform.SpanningTransformer {
+	return NewTransformer(r)
 }
 
 // rwLast writes the success of the last call to Rewrite as the first rune.


### PR DESCRIPTION
I noticed that your package had an internal adapter type like the one we've been discussing in CL 53810, so I thought I'd see what this was like if I exported it. I'm not sure that it's better or worse than having a "NewFromFunc" API; it's more flexible, but requires more boilerplate in the example.

I'm not submitting this for actual consideration; just because I thought it was interesting. Do with it what you will.